### PR TITLE
Add git to packages.yml

### DIFF
--- a/roles/common/tasks/packages.yml
+++ b/roles/common/tasks/packages.yml
@@ -52,6 +52,7 @@
       - mercurial
       - python-httplib2
       - logwatch
+      - git
 
 - name: set logwatch email
   template: >


### PR DESCRIPTION
Unsure what changed in local setup of Ansible or Vagrant but `make local standalone deploy` now hits : 

```
TASK: [noids | install latest noids code] ************************************* 
failed: [192.168.33.13] => {"changed": true, "cmd": ["/bin/env", "GOPATH=/opt/gocode", "/usr/bin/go", "get", "github.com/ndlib/noids"], "delta": "0:00:00.225694", "end": "2015-05-12 08:25:49.375375", "rc": 1, "start": "2015-05-12 08:25:49.149681", "warnings": []}
stderr: go: missing Git command. See http://golang.org/s/gogetcmd
package github.com/ndlib/noids: exec: "git": executable file not found in $PATH
```
